### PR TITLE
Fixed explicit cast for iOS

### DIFF
--- a/src/oatpp-websocket/SHA1.cpp
+++ b/src/oatpp-websocket/SHA1.cpp
@@ -251,7 +251,7 @@ void SHA1::update(std::istream &is) {
     
     char sbuf[BLOCK_BYTES];
     
-      is.read(sbuf, (long long)(BLOCK_BYTES - buffer.getSize()));
+      is.read(sbuf, (int)(BLOCK_BYTES - buffer.getSize()));
     buffer.write(sbuf, (std::size_t)is.gcount());
     
     if (buffer.getSize() != BLOCK_BYTES) {


### PR DESCRIPTION
Sorry! I accidentally used long long (the type it's converting from) instead of int (the type it's converting to).