### PR TITLE
Cross-compile Windows Fix

### DIFF
--- a/src/oatpp-websocket/AsyncWebSocket.cpp
+++ b/src/oatpp-websocket/AsyncWebSocket.cpp
@@ -27,7 +27,7 @@
 #include "./Utils.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif

--- a/src/oatpp-websocket/SHA1.cpp
+++ b/src/oatpp-websocket/SHA1.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif

--- a/src/oatpp-websocket/WebSocket.cpp
+++ b/src/oatpp-websocket/WebSocket.cpp
@@ -27,7 +27,7 @@
 #include "./Utils.hpp"
 
 #if defined(WIN32) || defined(_WIN32)
-  #include <WinSock2.h>
+  #include <winsock2.h>
 #else
   #include <arpa/inet.h>
 #endif


### PR DESCRIPTION
When cross-compiling using clang on Linux to target Windows, the build fails due to the mixed case spelling of the header includes. Clang expects the headers to be all lowercase.